### PR TITLE
Move the dashboard onto GitHub Actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -12,33 +12,15 @@ permissions: read-all
 
 jobs:
   R-CMD-check:
-    runs-on: ${{ matrix.config.os }}
-
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: macos-latest,   r: 'release'}
-          - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
-          - {os: ubuntu-latest,   r: 'release'}
-          - {os: ubuntu-latest,   r: 'oldrel-1'}
-
+    runs-on: ubuntu-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
-
     steps:
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-pandoc@v2
-
       - uses: r-lib/actions/setup-r@v2
         with:
-          r-version: ${{ matrix.config.r }}
-          http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -6,7 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
-name: R-CMD-check
+name: R-CMD-check.yaml
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -29,7 +31,7 @@ jobs:
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -47,3 +49,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -1,0 +1,37 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    paths: ['**.Rmd']
+
+name: render-rmarkdown.yaml
+
+permissions: read-all
+
+jobs:
+  render-rmarkdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+
+      - uses: r-lib/actions/setup-renv@v2
+
+      - name: Render Rmarkdown files and Commit Results
+        run: |
+          RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
+          Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
+          git config --local user.name "$GITHUB_ACTOR"
+          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git commit ${RMD_PATH[*]/.Rmd/.md} -m 'Re-build Rmarkdown files' || echo "No changes to commit"
+          git push origin || echo "No changes to commit"

--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -37,7 +37,14 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck
+          extra-packages: |
+            github::coatless-dashboard/tidyversedashboard
+            any::flexdashboard
+            any::codetools
+            any::ggplot2
+            any::forcats
+            any::jsonlite
+            github::hadley/emo
           needs: check
 
       - name: Setup Pages

--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   render-rmarkdown:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     environment:
       
       name: github-pages
@@ -52,6 +52,11 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+
+      - name: Sleep for 2 minutes
+        run: |
+            echo "Waiting 120 seconds before starting the queries..."
+            sleep 120  # Sleep for 2 minutes
 
       - name: Render Rmarkdown files
         run: |

--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -3,6 +3,9 @@ name: render-rmarkdown-pages
 on:
   push:
     paths: ['**.Rmd']
+  schedule:
+    # Runs at 5 PM PDT (UTC-7) which is midnight UTC-0
+    - cron: '0 0 * * *'
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -43,7 +46,13 @@ jobs:
       - name: Render Rmarkdown files
         run: |
           mkdir -p _site
-          RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
+          if [ "${{ github.event_name }}" == "push" ]; then
+            # For push events, only render changed files
+            RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
+          else
+            # For scheduled events, render all Rmd files
+            RMD_PATH=($(find . -name '*.Rmd'))
+          fi
           Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f, output_dir = "_site")' ${RMD_PATH[*]}
 
       - name: Upload artifact

--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -1,20 +1,28 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+# Workflow for rendering R Markdown files and deploying to GitHub Pages
+name: render-rmarkdown-pages
 on:
   push:
     paths: ['**.Rmd']
 
-name: render-rmarkdown.yaml
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
-permissions: read-all
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
   render-rmarkdown:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -22,16 +30,23 @@ jobs:
           fetch-depth: 0
 
       - uses: r-lib/actions/setup-pandoc@v2
-
       - uses: r-lib/actions/setup-r@v2
-
       - uses: r-lib/actions/setup-renv@v2
 
-      - name: Render Rmarkdown files and Commit Results
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Render Rmarkdown files
         run: |
+          mkdir -p _site
           RMD_PATH=($(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep '[.]Rmd$'))
-          Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f)' ${RMD_PATH[*]}
-          git config --local user.name "$GITHUB_ACTOR"
-          git config --local user.email "$GITHUB_ACTOR@users.noreply.github.com"
-          git commit ${RMD_PATH[*]/.Rmd/.md} -m 'Re-build Rmarkdown files' || echo "No changes to commit"
-          git push origin || echo "No changes to commit"
+          Rscript -e 'for (f in commandArgs(TRUE)) if (file.exists(f)) rmarkdown::render(f, output_dir = "_site")' ${RMD_PATH[*]}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: '_site'
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -22,10 +22,13 @@ jobs:
   render-rmarkdown:
     runs-on: ubuntu-latest
     environment:
+      
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # Use a personal access token with higher rate limits
+      GITHUB_PAT: ${{ secrets.GH_PAT }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -31,7 +31,11 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@v2
       - uses: r-lib/actions/setup-r@v2
-      - uses: r-lib/actions/setup-renv@v2
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ Depends:
     R (>= 3.4)
 Imports: 
     cranlogs,
+    cli, 
     desc,
     dplyr,
     DT,

--- a/tidyverse_dashboard.Rmd
+++ b/tidyverse_dashboard.Rmd
@@ -29,7 +29,7 @@ title: "`r params$title`"
 library(flexdashboard)
 library(gh)
 library(jsonlite)
-library(lubridate) 
+library(lubridate)
 library(forcats)
 library(dplyr)
 library(purrr)

--- a/tidyverse_dashboard.Rmd
+++ b/tidyverse_dashboard.Rmd
@@ -33,7 +33,7 @@ library(lubridate)
 library(forcats)
 library(dplyr)
 library(purrr)
-library(tibble)
+library(tibble) 
 library(codetools) # there was a weird error on connect that needed this
 library(DT)
 library(tidyversedashboard)

--- a/tidyverse_dashboard.Rmd
+++ b/tidyverse_dashboard.Rmd
@@ -29,7 +29,7 @@ title: "`r params$title`"
 library(flexdashboard)
 library(gh)
 library(jsonlite)
-library(lubridate)
+library(lubridate) 
 library(forcats)
 library(dplyr)
 library(purrr)

--- a/tidyverse_dashboard.Rmd
+++ b/tidyverse_dashboard.Rmd
@@ -33,7 +33,7 @@ library(lubridate)
 library(forcats)
 library(dplyr)
 library(purrr)
-library(tibble) 
+library(tibble)
 library(codetools) # there was a weird error on connect that needed this
 library(DT)
 library(tidyversedashboard)

--- a/tidyverse_dashboard.Rmd
+++ b/tidyverse_dashboard.Rmd
@@ -4,7 +4,7 @@ output:
     orientation: rows
     vertical_layout: fill
     theme: paper
-    source_code: "https://github.com/jimhester/tidyversedashboard"
+    source_code: "https://github.com/tidyverse/tidyversedashboard"
 params:
   title:
     label: Title of report


### PR DESCRIPTION
Hi, 

I noticed earlier today that the repo's URL (<https://tidyverse.org/dashboard>) was receiving a 404 from <https://colorado.posit.co/rsc/tidyverse-dashboard/>. 

![404 on colorado](https://github.com/user-attachments/assets/f8791c2d-78ad-47f2-a936-6ba0c699e609)

This PR address the 404 by moving it away from Colorado and onto GitHub through GitHub Actions with a GitHub Pages deploy. 

> [!NOTE]
>
> Due to the size of the dashboard, a personal GITHUB PAT token is required to avoid running into a stream issue. 